### PR TITLE
Allow API base URL via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,24 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Configuration
+
+The API endpoint used by the app can be set at build time using a
+`--dart-define` value. By default the app points to `http://localhost:5001`.
+
+To override this value when running or building the app, pass the `API_URL`
+define:
+
+```bash
+flutter run --dart-define=API_URL=https://api.example.com
+```
+
+When building for release, include the same flag:
+
+```bash
+flutter build apk --dart-define=API_URL=https://api.example.com
+```
+
+If no `API_URL` is provided, the development default (`http://localhost:5001`)
+is used.

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,6 @@
+class AppConfig {
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_URL',
+    defaultValue: 'http://localhost:5001',
+  );
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/nutrition_data.dart';
+import '../config.dart';
 
 class ApiService {
-  static const String baseUrl = 'http://localhost:5001';
+  static const String baseUrl = AppConfig.apiBaseUrl;
 
   static Future<NutritionResult> predictNutrition(NutritionData data) async {
     try {


### PR DESCRIPTION
## Summary
- use `AppConfig` for API base url
- add `config.dart` with default dev URL and override using `--dart-define`
- document how to set API endpoint in README

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500352b9688327ad21508341d38d54