### PR TITLE
Fix API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## API Configuration
+
+The application communicates with a backend API defined by the `API_URL`
+environment variable. If no value is provided, it defaults to
+`http://localhost:5001`.
+
+When running the app you can override this value using Flutter's
+`--dart-define` option:
+
+```bash
+flutter run --dart-define=API_URL=https://your-api-endpoint.com
+```
+
+Use the same flag when building release artifacts, e.g. `flutter build apk`.

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/nutrition_data.dart';
+import '../config.dart';
 
 class ApiService {
-  static const String baseUrl = 'http://localhost:5001';
+  static const String baseUrl = AppConfig.apiBaseUrl;
 
   static Future<NutritionResult> predictNutrition(NutritionData data) async {
     try {


### PR DESCRIPTION
## Summary
- reference `API_URL` environment variable inside `ApiService`
- explain API configuration in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850416b06e08327a66e89f567038ecf