### PR TITLE
Update widget test for NutriSafe

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nutrisafe/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Home screen displays action cards', (WidgetTester tester) async {
+    // Build the NutriSafe app and trigger a frame.
+    await tester.pumpWidget(const NutriSafeApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that key texts on the home screen are present.
+    expect(find.text('Nutrition Safety Scanner'), findsOneWidget);
+    expect(find.text('Scan Label'), findsOneWidget);
+    expect(find.text('Manual Input'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- update `widget_test.dart` to use `NutriSafeApp`
- assert texts from the NutriSafe home screen instead of the Flutter template counter

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046088cf0832789b92ebc1a3abe5a