### PR TITLE
Add usage disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ flutter run --dart-define=API_URL=https://your-api-endpoint.com
 ```
 
 Use the same flag when building release artifacts, e.g. `flutter build apk`.
+
+## Disclaimer
+
+Nutritional predictions produced by this application are for informational purposes only and do not constitute professional medical advice. The AI models behind these predictions may not be perfectly accurate.
+


### PR DESCRIPTION
## Summary
- add a disclaimer noting that the app's nutrition predictions are informational only
- clarify that the AI models may not be perfectly accurate

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504603d4988327b244b5aa62b8d934