### PR TITLE
Fix README API default URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ samples, guidance on mobile development, and a full API reference.
 
 The application communicates with a backend API defined by the `API_URL`
 environment variable. If no value is provided, it defaults to
-`http://localhost:5001`.
+`https://web-production-0fba.up.railway.app/`.
 
 When running the app you can override this value using Flutter's
 `--dart-define` option:


### PR DESCRIPTION
## Summary
- document the correct default API URL

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685061af32b8832787b482e76cac1d2a