### PR TITLE
Fix API base URL handling

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -4,7 +4,9 @@ import '../models/nutrition_data.dart';
 import '../config.dart';
 
 class ApiService {
-  static const String baseUrl = AppConfig.apiBaseUrl;
+  /// Base URL for all API requests without trailing slashes.
+
+  static final String baseUrl = AppConfig.apiBaseUrl.replaceAll(RegExp(r'/+$'), '');
 
   static Future<NutritionResult> predictNutrition(NutritionData data) async {
     try {

--- a/test/api_service_test.dart
+++ b/test/api_service_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nutrisafe/services/api_service.dart';
+
+void main() {
+  test('ApiService.baseUrl strips trailing slashes', () {
+    expect(ApiService.baseUrl.endsWith('/'), isFalse);
+  });
+
+  test('Endpoint URLs are generated correctly', () {
+    final base = ApiService.baseUrl;
+    expect(Uri.parse('$base/predict').toString(), '$base/predict');
+    expect(Uri.parse('$base/batch-predict').toString(), '$base/batch-predict');
+    expect(Uri.parse('$base/health').toString(), '$base/health');
+  });
+}


### PR DESCRIPTION
## Summary
- strip trailing slashes when defining `ApiService.baseUrl`
- keep baseUrl as a `final` variable
- test URL generation in ApiService

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685075c35e3c8327a869755ab783689f