### PR TITLE
Fix input field keyboard type

### DIFF
--- a/lib/screens/manual_input_screen.dart
+++ b/lib/screens/manual_input_screen.dart
@@ -165,7 +165,7 @@ class _ManualInputScreenState extends State<ManualInputScreen> {
         padding: const EdgeInsets.only(bottom: 15),
         child: TextFormField(
           controller: entry.value,
-          keyboardType: TextInputType.number,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
           decoration: InputDecoration(
             labelText: _labels[entry.key],
             border: const OutlineInputBorder(),


### PR DESCRIPTION
## Summary
- allow decimal input in manual entry fields

## Testing
- `flutter test test/widget_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685075d0e4e08327bae29f412087e153