### PR TITLE
Add INTERNET permission to release manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="nutrisafe"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- enable network access in release build of Android by adding `<uses-permission android:name="android.permission.INTERNET"/>`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850a0c74d3c8327be93167a217b1c39