### PR TITLE
Update widget test to use NutriSafeApp

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nutrisafe/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('NutriSafeApp smoke test', (WidgetTester tester) async {
+    // Build the app and trigger a frame.
+    await tester.pumpWidget(const NutriSafeApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the app shows the NutriSafe title.
+    expect(find.text('NutriSafe'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- update widget test to pump `NutriSafeApp`
- simplify expectations to check for the app title

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a0ceef188327b1465473e070175a