### PR TITLE
Allow runtime API_URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ samples, guidance on mobile development, and a full API reference.
 ## API Configuration
 
 The application communicates with a backend API defined by the `API_URL`
-environment variable. If no value is provided, it defaults to
-`https://web-production-0fba.up.railway.app/`.
+environment variable. The value can be supplied at build time with
+`--dart-define` or as a runtime environment variable. If neither is provided,
+it defaults to `https://web-production-0fba.up.railway.app/`.
 
 When running the app you can override this value using Flutter's
 `--dart-define` option:

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,6 +1,27 @@
+import 'dart:io';
+
+/// Application-wide configuration values.
 class AppConfig {
-  static const String apiBaseUrl = String.fromEnvironment(
-    'API_URL',
-    defaultValue: 'https://web-production-0fba.up.railway.app/',
-  );
+  /// Returns the base URL used for API requests.
+  ///
+  /// The value is resolved in the following order:
+  /// 1. Compile-time constant passed via `--dart-define=API_URL`.
+  /// 2. Runtime environment variable `API_URL` if available.
+  /// 3. A built-in default value.
+  static String get apiBaseUrl {
+    const compileTimeUrl = String.fromEnvironment('API_URL');
+    final runtimeUrl = Platform.environment['API_URL'];
+
+    final url = compileTimeUrl.isNotEmpty
+        ? compileTimeUrl
+        : (runtimeUrl != null && runtimeUrl.isNotEmpty)
+            ? runtimeUrl
+            : 'https://web-production-0fba.up.railway.app/';
+
+    return _stripTrailingSlashes(url);
+  }
+
+  /// Removes any trailing slashes from [url].
+  static String _stripTrailingSlashes(String url) =>
+      url.replaceAll(RegExp(r'/+\$'), '');
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -5,8 +5,7 @@ import '../config.dart';
 
 class ApiService {
   /// Base URL for all API requests without trailing slashes.
-
-  static final String baseUrl = AppConfig.apiBaseUrl.replaceAll(RegExp(r'/+$'), '');
+  static final String baseUrl = AppConfig.apiBaseUrl;
 
   static Future<NutritionResult> predictNutrition(NutritionData data) async {
     try {


### PR DESCRIPTION
## Summary
- support reading API_URL from runtime environment
- strip trailing slashes in `AppConfig`
- update `ApiService` to use sanitized base url
- document runtime API_URL option in README

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a420a8b88327a6a9acac480885cd